### PR TITLE
Harmonize actor id and network node id

### DIFF
--- a/main.py
+++ b/main.py
@@ -22,11 +22,12 @@ if __name__ == "__main__":
         if cfg.path.exists():
             raise Exception('The path: ' + str(cfg.path) + ' already exists with another file structure. '
                             'Please remove or rename folder to avoid confusion and restart simulation.')
-        nb_actors = 11
-        nb_nodes = 12
+        # TODO Use config file for scenario generation
+        nb_actors = 5
+        nb_nodes = 3
         sc = scenario.create_random(nb_nodes, nb_actors)
         sc.save(cfg.path, cfg.data_format)
-    # TODO make output folder for config file and Scenario json files, output series in csv and plots files
+    # TODO output folder: add plots files
 
     if cfg.show_plots:
         sc.power_network.plot()

--- a/simply/actor.py
+++ b/simply/actor.py
@@ -22,6 +22,7 @@ class Actor:
         """
         # TODO add battery component
         self.id = actor_id
+        self.grid_id = None
         self.t = 0
         self.horizon = cfg.parser.get("actor", "horizon", fallback=24)
         self.load_scale = ls

--- a/simply/market.py
+++ b/simply/market.py
@@ -79,8 +79,8 @@ class Market:
                     self.orders.loc[bid_id] = bid
                     matches.append({
                         "time": self.t,
-                        "bid_actor": int(bid.actor_id),
-                        "ask_actor": int(ask.actor_id),
+                        "bid_actor": bid.actor_id,
+                        "ask_actor": ask.actor_id,
                         "energy": energy,
                         "price": bid.price
                     })

--- a/simply/market_2pac.py
+++ b/simply/market_2pac.py
@@ -39,8 +39,8 @@ class TwoSidedPayAsClear(Market):
                 self.orders.loc[bid_id] = bid
                 matches.append({
                     "time": self.t,
-                    "bid_actor": int(bid.actor_id),
-                    "ask_actor": int(ask.actor_id),
+                    "bid_actor": bid.actor_id,
+                    "ask_actor": ask.actor_id,
                     "energy": energy,
                     "price": ask.price
                 })

--- a/simply/market_fair.py
+++ b/simply/market_fair.py
@@ -120,8 +120,8 @@ class BestMarket(Market):
                         # bid and ask match: append to local solution
                         _matches.append({
                             "time": self.t,
-                            "bid_actor": int(bid.actor_id),
-                            "ask_actor": int(ask.actor_id),
+                            "bid_actor": bid.actor_id,
+                            "ask_actor": ask.actor_id,
                             "energy": self.energy_unit,
                             "price": ask.adjusted_price,
                             # only for removing doubles later

--- a/simply/scenario.py
+++ b/simply/scenario.py
@@ -137,11 +137,10 @@ def load(dirpath, data_format):
 
 
 def create_random(num_nodes, num_actors):
-    assert num_actors < num_nodes
     pn = power_network.create_random(num_nodes)
-    actors = [actor.create_random(i) for i in range(num_actors)]
+    actors = [actor.create_random("H" + str(i)) for i in range(num_actors)]
 
-    # Add actor nodes at random position in the network
+    # Add actor nodes at random position (leaf node) in the network
     # One network node can contain several actors (using random.choices method)
     map_actors = pn.add_actors_random(actors)
 
@@ -152,7 +151,7 @@ def create_random2(num_nodes, num_actors):
     assert num_actors < num_nodes
     # num_actors has to be much smaller than num_nodes
     pn = power_network.create_random(num_nodes)
-    actors = [actor.create_random(i) for i in range(num_actors)]
+    actors = [actor.create_random("H" + str(i)) for i in range(num_actors)]
 
     # Give actors a random position in the network
     actor_nodes = random.sample(pn.leaf_nodes, num_actors)


### PR DESCRIPTION
- make default actor id a string for network, actor and orders
- make generation of random szenarios more generic
- fix: use all leaf nodes, do not assume root node confusion with leaf
- add grid id to Actor class

Solves: #34