### PR TITLE
Correct bid ask confusion in tests and adapt to desired matching function call

### DIFF
--- a/tests/test_market.py
+++ b/tests/test_market.py
@@ -31,31 +31,31 @@ class TestMarket:
         m = Market(0)
         assert m.get_bids().shape[0] == 0
         # add ask
-        m.accept_order(Order(-1,0,0,1,1), None)
+        m.accept_order(Order(1,0,0,1,1), None)
         assert m.get_bids().shape[0] == 0
         # add bid
-        m.accept_order(Order(1,0,0,1,1), None)
+        m.accept_order(Order(-1,0,0,1,1), None)
         assert m.get_bids().shape[0] == 1
         # and one more bid
-        m.accept_order(Order(1,0,1,2,1), None)
+        m.accept_order(Order(-1,0,1,2,1), None)
         assert m.get_bids().shape[0] == 2
 
     def test_get_asks(self):
         m = Market(0)
         assert m.get_asks().shape[0] == 0
         # add bid
-        m.accept_order(Order(1,0,0,1,1), None)
+        m.accept_order(Order(-1,0,0,1,1), None)
         assert m.get_asks().shape[0] == 0
         # add ask
-        m.accept_order(Order(-1,0,0,1,1), None)
+        m.accept_order(Order(1,0,0,1,1), None)
         assert m.get_asks().shape[0] == 1
         # and one more bid
-        m.accept_order(Order(-1,0,1,2,1), None)
+        m.accept_order(Order(1,0,1,2,1), None)
         assert m.get_asks().shape[0] == 2
 
     def test_clear(self):
         m = Market(0)
-        m.accept_order(Order(1,0,0,1,1), None)
+        m.accept_order(Order(-1,0,0,1,1), None)
         # no match possible (only one order)
         m.clear(reset=False)
         # new list of matches saved
@@ -78,11 +78,13 @@ class TestPayAsBid():
     def test_basic(self):
         m = Market(0)
         # no orders
-        assert len(m.match()) == 0
+        m.define_order_id()
+        assert len(m.match(m.get_order_dict())) == 0
         # bid and ask with same energy and price
-        m.accept_order(Order(1,0,0,1,1), None)
-        m.accept_order(Order(-1,0,1,1,1), None)
-        matches = m.match()
+        m.accept_order(Order(-1,0,0,1,1), None)
+        m.accept_order(Order(1,0,1,1,1), None)
+        m.define_order_id()
+        matches = m.match(m.get_order_dict())
         assert len(matches) == 1
         # check match
         assert matches[0]["time"] == 0
@@ -95,17 +97,19 @@ class TestPayAsBid():
         # different prices, pay as bid
         m = Market(0)
         # ask above bid: no match
-        m.accept_order(Order(1,0,0,1,2), None)
-        m.accept_order(Order(-1,0,1,1,2.5), None)
-        matches = m.match()
+        m.accept_order(Order(-1,0,0,1,2), None)
+        m.accept_order(Order(1,0,1,1,2.5), None)
+        m.define_order_id()
+        matches = m.match(m.get_order_dict())
         assert len(matches) == 0
 
         # reset orders
         m.orders = m.orders[:0]
         # ask below bid: match with bid price
-        m.accept_order(Order(1,0,0,1,2), None)
-        m.accept_order(Order(-1,0,1,1,.5), None)
-        matches = m.match()
+        m.accept_order(Order(-1,0,0,1,2), None)
+        m.accept_order(Order(1,0,1,1,.5), None)
+        m.define_order_id()
+        matches = m.match(m.get_order_dict())
         assert len(matches) == 1
         assert matches[0]["energy"] == 1
         assert matches[0]["price"] == 2
@@ -113,38 +117,42 @@ class TestPayAsBid():
     def test_energy(self):
         # different energies
         m = Market(0)
-        m.accept_order(Order(1,0,0,.1,1), None)
-        m.accept_order(Order(-1,0,1,1,1), None)
-        matches = m.match()
+        m.accept_order(Order(-1,0,0,.1,1), None)
+        m.accept_order(Order(1,0,1,1,1), None)
+        m.define_order_id()
+        matches = m.match(m.get_order_dict())
         assert len(matches) == 1
         assert matches[0]["energy"] == 0.1
 
         m.orders = m.orders[:0]
-        m.accept_order(Order(1,0,0,100,1), None)
-        m.accept_order(Order(-1,0,1,.3,1), None)
-        matches = m.match()
+        m.accept_order(Order(-1,0,0,100,1), None)
+        m.accept_order(Order(1,0,1,.3,1), None)
+        m.define_order_id()
+        matches = m.match(m.get_order_dict())
         assert len(matches) == 1
         assert matches[0]["energy"] == 0.3
 
     def test_multiple(self):
         # multiple bids to satisfy one ask
         m = Market(0)
-        m.accept_order(Order(1,0,0,.1,1), None)
-        m.accept_order(Order(1,0,1,11,1), None)
-        m.accept_order(Order(-1,0,2,2,1), None)
-        matches = m.match()
+        m.accept_order(Order(-1,0,0,.1,1), None)
+        m.accept_order(Order(-1,0,1,11,1), None)
+        m.accept_order(Order(1,0,2,2,1), None)
+        m.define_order_id()
+        matches = m.match(m.get_order_dict())
         assert len(matches) == 2
         assert matches[0]["energy"] == 0.1
         assert matches[1]["energy"] == 1.9  # only 2 in ask
 
         # multiple asks to satisfy one bid (in-order)
         m.orders = m.orders[:0]
-        m.accept_order(Order(1,0,0,100,1), None)
-        m.accept_order(Order(-1,0,1,10,1), None)
-        m.accept_order(Order(-1,0,2,20,1), None)
-        m.accept_order(Order(-1,0,3,30,1), None)
-        m.accept_order(Order(-1,0,4,50,1), None)
-        matches = m.match()
+        m.accept_order(Order(-1,0,0,100,1), None)
+        m.accept_order(Order(1,0,1,10,1), None)
+        m.accept_order(Order(1,0,2,20,1), None)
+        m.accept_order(Order(1,0,3,30,1), None)
+        m.accept_order(Order(1,0,4,50,1), None)
+        m.define_order_id()
+        matches = m.match(m.get_order_dict())
         assert len(matches) == 4
         assert matches[0]["energy"] == 10
         assert matches[1]["energy"] == 20

--- a/tests/test_market_2pac.py
+++ b/tests/test_market_2pac.py
@@ -4,17 +4,20 @@ from simply.market_2pac import TwoSidedPayAsClear
 def test_basic():
     m = TwoSidedPayAsClear(0)
     # no orders: no matches
-    matches = m.match(show=False)
+    m.define_order_id()
+    matches = m.match(m.get_order_dict())
     assert len(matches) == 0
 
     # only one type: no match
-    m.accept_order(Order(1,0,0,1,1), None)
-    matches = m.match(show=False)
+    m.accept_order(Order(-1,0,0,1,1), None)
+    m.define_order_id()
+    matches = m.match(m.get_order_dict())
     assert len(matches) == 0
 
     # bid and ask with same energy and price
-    m.accept_order(Order(-1,0,1,1,1), None)
-    matches = m.match(show=False)
+    m.accept_order(Order(1,0,1,1,1), None)
+    m.define_order_id()
+    matches = m.match(m.get_order_dict())
     assert len(matches) == 1
     # check match
     assert matches[0]["time"] == 0
@@ -27,17 +30,19 @@ def test_prices():
     # different prices
     m = TwoSidedPayAsClear(0)
     # ask above bid: no match
-    m.accept_order(Order(1,0,0,1,2), None)
-    m.accept_order(Order(-1,0,1,1,2.5), None)
-    matches = m.match(show=False)
+    m.accept_order(Order(-1,0,0,1,2), None)
+    m.accept_order(Order(1,0,1,1,2.5), None)
+    m.define_order_id()
+    matches = m.match(m.get_order_dict())
     assert len(matches) == 0
 
     # reset orders
     m.orders = m.orders[:0]
     # ask below bid: take lower one
-    m.accept_order(Order(1,0,0,1,2.5), None)
-    m.accept_order(Order(-1,0,1,1,2), None)
-    matches = m.match(show=False)
+    m.accept_order(Order(-1,0,0,1,2.5), None)
+    m.accept_order(Order(1,0,1,1,2), None)
+    m.define_order_id()
+    matches = m.match(m.get_order_dict())
     assert len(matches) == 1
     assert matches[0]["energy"] == 1
     assert matches[0]["price"] == 2
@@ -45,38 +50,43 @@ def test_prices():
 def test_energy():
     # different energies
     m = TwoSidedPayAsClear(0)
-    m.accept_order(Order(1,0,0,.1,1), None)
-    m.accept_order(Order(-1,0,1,1,1), None)
-    matches = m.match(show=False)
+    m.accept_order(Order(-1,0,0,.1,1), None)
+    m.accept_order(Order(1,0,1,1,1), None)
+    m.define_order_id()
+    matches = m.match(m.get_order_dict())
     assert len(matches) == 1
     assert matches[0]["energy"] == 0.1
 
     m.orders = m.orders[:0]
-    m.accept_order(Order(1,0,0,100,1), None)
-    m.accept_order(Order(-1,0,1,.3,1), None)
-    matches = m.match(show=False)
+    m.accept_order(Order(-1,0,0,100,1), None)
+    m.accept_order(Order(1,0,1,.3,1), None)
+    m.define_order_id()
+    matches = m.match(m.get_order_dict())
     assert len(matches) == 1
     assert matches[0]["energy"] == 0.3
 
 def test_multiple():
     # multiple bids to satisfy one ask
     m = TwoSidedPayAsClear(0)
-    m.accept_order(Order(1,0,0,.1,3), None)
-    m.accept_order(Order(1,0,1,11,1.1), None)
-    m.accept_order(Order(-1,0,2,2,1), None)
-    matches = m.match(show=False)
+    m.accept_order(Order(-1, 0, 1, 11, 1.1), None)
+    m.accept_order(Order(-1,0,0,.1,3), None)
+    m.accept_order(Order(1,0,2,2,1), None)
+    m.define_order_id()
+    matches = m.match(m.get_order_dict())
     assert len(matches) == 2
     assert matches[0]["energy"] == 0.1
     assert matches[1]["energy"] == 1.9  # only 2 in ask
 
     # multiple asks to satisfy one bid (order by price)
     m.orders = m.orders[:0]
-    m.accept_order(Order(-1,0,1,10,1), None)
-    m.accept_order(Order(-1,0,2,20,2), None)
-    m.accept_order(Order(-1,0,3,30,3), None)
-    m.accept_order(Order(-1,0,4,50,4), None)
-    m.accept_order(Order(1,0,0,100,5), None)
-    matches = m.match(show=False)
+    m.accept_order(Order(1, 0, 3, 30, 3), None)
+    m.accept_order(Order(1, 0, 4, 50, 4), None)
+    m.accept_order(Order(-1, 0, 0, 100, 5), None)
+    m.accept_order(Order(1,0,1,10,1), None)
+    m.accept_order(Order(1,0,2,20,2), None)
+
+    m.define_order_id()
+    matches = m.match(m.get_order_dict())
     assert len(matches) == 4
     assert matches[0]["energy"] == 10
     assert matches[1]["energy"] == 20

--- a/tests/test_market_fair.py
+++ b/tests/test_market_fair.py
@@ -14,17 +14,20 @@ class TestBestMarket:
     def test_basic(self):
         m = BestMarket(0, self.pn)
         # no orders: no matches
-        matches = m.match()
+        m.define_order_id()
+        matches = m.match(m.get_order_dict())
         assert len(matches) == 0
 
         # only one type: no match
-        m.accept_order(Order(1,0,2,1,1), None)
-        matches = m.match()
+        m.accept_order(Order(-1,0,2,1,1), None)
+        m.define_order_id()
+        matches = m.match(m.get_order_dict())
         assert len(matches) == 0
 
         # bid and ask with same energy and price
-        m.accept_order(Order(-1,0,3,1,1), None)
-        matches = m.match()
+        m.accept_order(Order(1,0,3,1,1), None)
+        m.define_order_id()
+        matches = m.match(m.get_order_dict())
         assert len(matches) == 1
         # check match
         assert matches[0]["time"] == 0
@@ -37,33 +40,37 @@ class TestBestMarket:
         # different prices
         m = BestMarket(0, self.pn)
         # ask above bid: no match
-        m.accept_order(Order(1,0,2,1,2), None)
-        m.accept_order(Order(-1,0,3,1,2.5), None)
-        matches = m.match()
+        m.accept_order(Order(-1,0,2,1,2), None)
+        m.accept_order(Order(1,0,3,1,2.5), None)
+        m.define_order_id()
+        matches = m.match(m.get_order_dict())
         assert len(matches) == 0
 
         # reset orders
         m.orders = m.orders[:0]
         # ask below bid: take highest asking price
-        m.accept_order(Order(1,0,2,1,2.5), None)
-        m.accept_order(Order(-1,0,3,1,2), None)
-        matches = m.match()
+        m.accept_order(Order(-1,0,2,1,2.5), None)
+        m.accept_order(Order(1,0,3,1,2), None)
+        m.define_order_id()
+        matches = m.match(m.get_order_dict())
         assert len(matches) == 1
         assert matches[0]["energy"] == pytest.approx(1)
         assert matches[0]["price"] == pytest.approx(2)
 
         m.orders = m.orders[:0]
         # weight between nodes too high
-        m.accept_order(Order(1,0,2,1,3), None)
-        m.accept_order(Order(-1,0,4,1,3), None)
-        matches = m.match()
+        m.accept_order(Order(-1,0,2,1,3), None)
+        m.accept_order(Order(1,0,4,1,3), None)
+        m.define_order_id()
+        matches = m.match(m.get_order_dict())
         assert len(matches) == 0
 
         m.orders = m.orders[:0]
         # weight between nodes low enough
-        m.accept_order(Order(1,0,4,1,3), None)
-        m.accept_order(Order(-1,0,2,1,2), None)
-        matches = m.match()
+        m.accept_order(Order(-1,0,4,1,3), None)
+        m.accept_order(Order(1,0,2,1,2), None)
+        m.define_order_id()
+        matches = m.match(m.get_order_dict())
         assert len(matches) == 1
         assert matches[0]["energy"] == pytest.approx(1)
         assert matches[0]["price"] == pytest.approx(3)  # 2 + weight(1)
@@ -71,38 +78,42 @@ class TestBestMarket:
     def test_energy(self):
         # different energies
         m = BestMarket(0, self.pn)
-        m.accept_order(Order(1,0,2,.1,1), None)
-        m.accept_order(Order(-1,0,3,1,1), None)
-        matches = m.match()
+        m.accept_order(Order(-1,0,2,.1,1), None)
+        m.accept_order(Order(1,0,3,1,1), None)
+        m.define_order_id()
+        matches = m.match(m.get_order_dict())
         assert len(matches) == 1
         assert matches[0]["energy"] == pytest.approx(0.1)
 
         m.orders = m.orders[:0]
-        m.accept_order(Order(1,0,2,100,1), None)
-        m.accept_order(Order(-1,0,3,.3,1), None)
-        matches = m.match()
+        m.accept_order(Order(-1,0,2,100,1), None)
+        m.accept_order(Order(1,0,3,.3,1), None)
+        m.define_order_id()
+        matches = m.match(m.get_order_dict())
         assert len(matches) == 1
         assert matches[0]["energy"] == pytest.approx(0.3)
 
     def test_multiple(self):
         # multiple bids to satisfy one ask
         m = BestMarket(0, self.pn)
-        m.accept_order(Order(1,0,2,.1,4), None)
-        m.accept_order(Order(1,0,3,3,3), None)
-        m.accept_order(Order(-1,0,4,2,1), None)
-        matches = m.match()
+        m.accept_order(Order(-1,0,2,.1,4), None)
+        m.accept_order(Order(-1,0,3,3,3), None)
+        m.accept_order(Order(1,0,4,2,1), None)
+        m.define_order_id()
+        matches = m.match(m.get_order_dict())
         assert len(matches) == 2
         assert matches[0]["energy"] == pytest.approx(0.1)
         assert matches[1]["energy"] == pytest.approx(1.9)  # only 2 in ask
 
         # multiple asks to satisfy one bid
         m.orders = m.orders[:0]
-        m.accept_order(Order(-1,0,2,10,1), None)
-        m.accept_order(Order(-1,0,2,20,2), None)
-        m.accept_order(Order(-1,0,3,30,3), None)
-        m.accept_order(Order(-1,0,3,50,4), None)
-        m.accept_order(Order(1,0,4,100,5), None)
-        matches = m.match()
+        m.accept_order(Order(1,0,2,10,1), None)
+        m.accept_order(Order(1,0,2,20,2), None)
+        m.accept_order(Order(1,0,3,30,3), None)
+        m.accept_order(Order(1,0,3,50,4), None)
+        m.accept_order(Order(-1,0,4,100,5), None)
+        m.define_order_id()
+        matches = m.match(m.get_order_dict())
         assert len(matches) == 4
         assert matches[0]["energy"] == pytest.approx(10)
         assert matches[1]["energy"] == pytest.approx(20)


### PR DESCRIPTION
(1)
interchange Order(-1,...) and Order(1,...)
according to fixing commit 583fb137b12d3410c23377a4fdbf8893563d9c0b

(2)
Adapt function call to prepare for desired parameter-based matching function
`m.match()`
to
```
m.define_order_id()
matches = m.match(m.get_order_dict())
```