### PR TITLE
market wrapper for myco API

### DIFF
--- a/market_wrapper.py
+++ b/market_wrapper.py
@@ -28,8 +28,8 @@ def generate_recommendations(market_id, time, bids, asks, matches):
         recommendations.append({
             "market_id": market_id,
             "time_slot": time,
-            "bids": bids[match["bid_actor"]],
-            "offers": asks[match["ask_actor"]],
+            "bids": [bids[match["bid_actor"]]],
+            "offers": [asks[match["ask_actor"]]],
             "selected_energy": match["energy"] / ENERGY_UNIT_CONVERSION_FACTOR,
             "trade_rate": match["price"],
         })


### PR DESCRIPTION
How to use: call script with JSON of myco API matching data: `python market_wrapper.py myco.json`

Observations:
* identified likely candidates for helper functions (parsing/translation between D3A and simply)
* market timeslot and order timeslots are different (seconds missing in market time info), so added missing string part manually
* what is energy unit in D3A? Introduced energy unit conversion factor (simply: kW)
* in example recommendation, lots of useless data is transmitted. Why are bids and offers repeated (D3A already knows about them) instead of sending order id? It also looks like bid and offer for every match is transmitted in array, although often only one bid and one offer is matched. Simply is more about actors, since usually actors don't care what specific order matched, just that any order of theirs matched.