### PR TITLE
Add cluster clearing price test.

### DIFF
--- a/simply/market_fair.py
+++ b/simply/market_fair.py
@@ -145,11 +145,11 @@ class BestMarket(Market):
                         if _match["price"] > match["price"]:
                             # new match is better:
                             # exclude old match
-                            exclude[match["ask_cluster"]].add(match["ask_id"])
+                            exclude[match["bid_cluster"]].add(match["ask_id"])
                             # replace old match
                             matches[match_idx] = _match
                             # redo other cluster
-                            clusters_to_match.add(match["ask_cluster"])
+                            clusters_to_match.add(match["bid_cluster"])
                         else:
                             # old match is better: exclude new match
                             exclude[cluster_idx].add(_match["ask_id"])

--- a/tests/test_market_fair.py
+++ b/tests/test_market_fair.py
@@ -307,4 +307,4 @@ class TestBestMarket:
         m.accept_order(Order(1, 0, 3, 1, 0.1, 6))
         m.accept_order(Order(1, 0, 3, 1, 0.1, 4))
         matches = m.match()
-        assert len(matches) == 1
+        assert len(matches) == 2


### PR DESCRIPTION
Fixes #90

While looking into the initial error and creating this test. I came across this:

## Current Approach to Disputed Order:

**Cluster 0**

Initial match attempt:

| Bids | Asks | Matched Price |
| --- | --- | --- |
| Participant 0, energy 0.1, price 10 | Participant 3, energy 0.1, price 5 | 5 |
|  | Participant 3, energy 0.1, price 7 |  |

**Cluster 1**

Initial match attempt:

| Bids | Asks | Matched Price |
| --- | --- | --- |
| Participant 1, energy 0.1 , price 10 | Participant 3, energy 0.1, price 4 | 6 |
| Participant 1, energy 0.1, price 7 | Participant 3, energy 0.1, price 6 | 6 |

Match disputed.

Order remove and cluster reevaluated.

**Final matches:**

| Bids | Asks | Matched Price |
| --- | --- | --- |
| Participant 1, energy 0.1 , price 10 | Participant 3, energy 0.1, price 6 | 6 |
| Participant 1, energy 0.1, price 7 |  |  |

---

## Alternative Approach:

**Cluster 0**

Initial match attempt:

| Bids | Asks | Matched Price |
| --- | --- | --- |
| Participant 0, energy 0.1, price 10 | Participant 3, energy 0.1, price 5 | 5 |
|  | Participant 3, energy 0.1, price 7 |  |

**Cluster 1**

Initial match attempt:

| Bids | Asks | Matched Price |
| --- | --- | --- |
| Participant 1, energy 0.1 , price 10 | Participant 3, energy 0.1, price 4 | 4 |
| Participant 1, energy 0.1, price 7 | Participant 3, energy 0.1, price 6 |  |

Match disputed.

Order remove and cluster reevaluated:

| Bids | Asks | Matched Price |
| --- | --- | --- |
| Participant 1, energy 0.1 , price 10 | Participant 3, energy 0.1, price 6 | 6 |
| Participant 1, energy 0.1, price 7 |  |  |
|  |  |  |

**Final matches:**

| Bids | Asks | Matched Price |
| --- | --- | --- |
| Participant 0, energy 0.1, price 10 | Participant 3, energy 0.1, price 5 | 6 |
| Participant 1, energy 0.1 , price 10 | Participant 3, energy 0.1, price 6 | 6 |
