### PR TITLE
Update market_wrapper.py to allow BEST matching in SMBS

### DIFF
--- a/simply/market_wrapper.py
+++ b/simply/market_wrapper.py
@@ -108,7 +108,7 @@ class BestClusterPayAsClearMatchingAlgorithm(MatchingAlgorithm):
     def get_matches_recommendations(cls, mycoDict, grid_fee_matrix=None):
         """
         :param grid_fee_matrix: two-dimensional nXn list used to calculate grid-fees e.g.,
-            [[0,1],[1,0]"""
+            [[0,1],[1,0]]"""
 
         pn = power_network.create_random(1)
         recommendations = []


### PR DESCRIPTION
The market wrapper needs to be able to process grid fee matrix to allow for BEST matching in the SMBS repository. This could be extended further to allow other matching algorithms to process grid fee matrices #120.