### PR TITLE
Add csv based scenario generation

### DIFF
--- a/generate_scenario_example.py
+++ b/generate_scenario_example.py
@@ -1,0 +1,30 @@
+from argparse import ArgumentParser
+from pathlib import Path
+
+from simply import scenario
+from simply.config import Config
+
+if __name__ == "__main__":
+    parser = ArgumentParser(description='Entry point for market simulation')
+    parser.add_argument('config', nargs='?', default="", help='configuration file')
+    args = parser.parse_args()
+
+    cfg = Config(args.config)
+    sc = scenario.create_scenario_from_csv(
+        Path("sample", "households_sample"),
+        5,
+        12,
+        0.01,
+        nb_ts=3*96
+    )
+    sc.save(cfg.path, cfg.data_format)
+
+    if cfg.show_plots:
+        sc.power_network.plot()
+        sc.plot_actor_data()
+    sc.power_network.to_image()
+    sc.power_network.to_json()
+    if cfg.show_prints:
+        print(sc.to_dict())
+        print(sc.power_network.short_paths)
+        print(sc)

--- a/main.py
+++ b/main.py
@@ -61,7 +61,8 @@ if __name__ == "__main__":
         for a in sc.actors:
             # TODO concurrent bidding of actors
             order = a.generate_order()
-            m.accept_order(order, callback=a.receive_market_results)
+            if order:
+                m.accept_order(order, callback=a.receive_market_results)
 
         m.clear(reset=cfg.reset_market)
         if cfg.show_prints:

--- a/simply/actor.py
+++ b/simply/actor.py
@@ -273,7 +273,6 @@ def create_from_csv(actor_id, asset_dict={}, start_date="2021-01-01", nb_ts=None
     df = pd.DataFrame([], columns=cols)
 
     # Read csv files for each asset
-    csv_peak = {}
     for col, csv_dict in asset_dict.items():
         # if csv_dict is empty
         if not csv_dict:

--- a/simply/actor.py
+++ b/simply/actor.py
@@ -76,7 +76,7 @@ class Actor:
         # TODO add battery component
         self.id = actor_id
         self.grid_id = None
-        self.t = 0
+        self.t = cfg.parser.getint("default", "start", fallback=0)
         self.horizon = cfg.parser.get("actor", "horizon", fallback=24)
 
         self.load_scale = ls
@@ -85,25 +85,20 @@ class Actor:
         self.battery = None
         self.data = pd.DataFrame()
         self.pred = pd.DataFrame()
+        self.pm = pd.DataFrame()
         if csv is not None:
             self.csv_file = csv
         else:
             self.csv_file = f'actor_{actor_id}.csv'
-        for column, scale in [("load", ls), ("pv", ps), ("prices", 1)]:
+        for column, scale in [("load", ls), ("pv", ps), ("prices", 1), ("schedule", 1)]:
             self.data[column] = scale * df[column]
             try:
-                prediction_multiplier = np.array(pm[column])
+                self.pm[column] = np.array(pm[column])
             except KeyError:
                 prediction_multiplier = self.error_scale * np.random.rand(self.horizon)
-                pm[column] = prediction_multiplier.tolist()
-            self.pred[column] = self.data[column].iloc[self.t: self.t + self.horizon] \
-                + prediction_multiplier
+                self.pm[column] = prediction_multiplier.tolist()
 
-        if "schedule" in df.columns:
-            self.pred["schedule"] = df["schedule"]
-        else:
-            # perfect foresight
-            self.pred["schedule"] = self.pred["pv"] - self.pred["load"]
+        self.update()
         self.orders = []
         self.traded = {}
         self.args = {"id": actor_id, "df": df.to_json(), "csv": csv, "ls": ls, "ps": ps,
@@ -120,6 +115,15 @@ class Actor:
         ).plot()
         plt.show()
 
+    def update(self):
+        for column in ["load", "pv", "prices", "schedule"]:
+            if column in self.data.columns:
+                self.pred[column] = self.data[column].iloc[
+                                        self.t: self.t + self.horizon
+                                    ].reset_index(drop=True) + self.pm[column]
+        if "schedule" not in self.data.columns:
+            self.pred["schedule"] = self.pred["pv"] - self.pred["load"]
+
     def generate_order(self):
         """
         Generate new order for current time slot according to predicted schedule
@@ -129,15 +133,19 @@ class Actor:
         :rtype: Order
         """
         # TODO calculate amount of energy to fulfil personal schedule
-        energy = self.pred["schedule"][self.t]
+        energy = self.pred["schedule"][0]
+        if energy == 0:
+            return None
         # TODO simulate strategy: manipulation, etc.
-        price = self.pred["prices"][self.t]
+        price = self.pred["prices"][0]
         # TODO take flexibility into account to generate the bid
 
         # TODO replace order type by enum
         new = Order(np.sign(energy), self.t, self.id, None, abs(energy), price)
         self.orders.append(new)
+        # update schedule for next time step
         self.t += 1
+        self.update()
 
         return new
 
@@ -189,8 +197,7 @@ class Actor:
         #  also errors need to be saved
         if self.error_scale != 0:
             raise Exception('Prediction Error is not yet implemented!')
-        save_df = pd.concat([self.data[["load", "pv"]],
-                             self.pred[["schedule", "prices"]]], axis=1)
+        save_df = self.data[["load", "pv", "schedule", "prices"]]
         save_df.to_csv(dirpath.joinpath(self.csv_file))
 
 
@@ -223,6 +230,82 @@ def create_random(actor_id, start_date="2021-01-01", nb_ts=24, ts_hour=1):
     ps = random.choices([0, ps], [1-pv_prob, pv_prob], k=1)
     df["schedule"] = ps * df["pv"] - ls * df["load"]
     max_price = 0.3
+    df["prices"] *= max_price
+    # Adapt order price by a factor to compensate net pricing of ask orders
+    # (i.e. positive power) Bids however include network charges
+    net_price_factor = 0.7
+    df["prices"] = df.apply(
+        lambda slot: slot["prices"] - (slot["schedule"] > 0) * net_price_factor
+        * slot["prices"], axis=1
+    )
+
+    return Actor(actor_id, df, ls=ls, ps=ps)
+
+
+def create_from_csv(actor_id, asset_dict={}, start_date="2021-01-01", nb_ts=None, ts_hour=1):
+    """
+    Create actor instance with random asset time series and random scaling factors. Replace
+
+    :param str actor_id: unique actor identifier
+    :param Dict asset_dict: nested dictionary specifying 'csv' filename and column ('col_index')
+        per Actor asset
+    :param str start_date: Start date "YYYY-MM-DD" of the DataFrameIndex for the generated actor's
+        asset time series
+    :param int nb_ts: number of time slots that should be generated, derived from csv if None
+    :param ts_hour: number of time slots per hour, e.g. 4 results in 15min time slots
+    :return: generated Actor object
+    :rtype: Actor
+    """
+    # Random scale factor generation, load and price time series in boundaries
+    ls = random.uniform(0.8, 1.3) / ts_hour
+    ps = random.uniform(1, 7) / ts_hour
+    # Probability of an actor to possess a PV, here 40%
+    pv_prob = 0.4
+    ps = random.choices([0, ps], [1 - pv_prob, pv_prob], k=1)
+
+    # Initialize DataFrame
+    cols = ["load", "pv", "schedule", "prices"]
+    df = pd.DataFrame([], columns=cols)
+
+    # Read csv files for each asset
+    csv_peak = {}
+    for col, csv_dict in asset_dict.items():
+        # if csv_dict is empty
+        if not csv_dict:
+            continue
+        csv_df = pd.read_csv(
+            csv_dict["csv"],
+            sep=',',
+            parse_dates=['Time'],
+            dayfirst=True
+        )
+        # Rename column and insert data based on dictionary
+        df.loc[:, col] = csv_df.iloc[:nb_ts, csv_dict["col_index"]]
+        # Save peak value and normalize time series
+        csv_peak[col] = df[col].max()
+        df[col] = df[col] / df[col].max()
+    # Set index
+    if "index" not in df.columns:
+        df["index"] = pd.date_range(
+            start_date,
+            freq="{}min".format(int(60 / ts_hour)),
+            periods=nb_ts
+        )
+    df = df.set_index("index")
+
+    # If pv asset key is present but dictionary does not contain a filename
+    if "pv" in asset_dict.keys() and not asset_dict["pv"].get("filename"):
+        # Initialize PV with random noise
+        df["pv"] = np.random.rand(nb_ts, 1)
+        # Multiply random generation signal with gaussian/PV-like characteristic per day
+        for day in daily(df, 24 * ts_hour):
+            day["pv"] *= gaussian_pv(ts_hour, 3)
+
+    # Dummy-Strategy:
+    # Predefined energy management, energy volume and price for trades due to no flexibility
+    df["schedule"] = ps * df["pv"] - ls * df["load"]
+    max_price = 0.3
+    df["prices"] = np.random.rand(nb_ts, 1)
     df["prices"] *= max_price
     # Adapt order price by a factor to compensate net pricing of ask orders
     # (i.e. positive power) Bids however include network charges

--- a/simply/market.py
+++ b/simply/market.py
@@ -69,6 +69,13 @@ class Market:
         if order.time != self.t:
             raise ValueError("Wrong order time ({}), market is at time {}".format(order.time,
                                                                                   self.t))
+        # Ignore Orders without energy volume
+        if order.energy == 0:
+            return
+
+        if not order.price:
+            raise ValueError("Wrong order price ({})".format(order.price))
+
         if order.type not in [-1, 1]:
             raise ValueError("Wrong order type ({})".format(order.type))
 
@@ -123,7 +130,7 @@ class Market:
 
         if reset:
             # don't retain orders for next cycle
-            self.orders = pd.DataFrame()
+            self.orders = pd.DataFrame(columns=Order._fields)
         else:
             # remove fully matched orders
             self.orders = self.orders[self.orders.energy >= self.energy_unit]

--- a/simply/scenario.py
+++ b/simply/scenario.py
@@ -205,7 +205,8 @@ def create_scenario_from_csv(dirpath, num_nodes, num_actors, weight_factor, ts_h
     :param num_nodes: number of nodes in the network
     :param num_actors: number of actors in the network
     :param weight_factor: weight factor used to derive grid fees
-    :param nb_ts: number of
+    :param ts_hour: number of time slot of equal length within one hour
+    :param nb_ts: number of time slots to be generated
     """
     # Create random nodes for power network
     pn = power_network.create_random(num_nodes)

--- a/simply/util.py
+++ b/simply/util.py
@@ -7,6 +7,7 @@ def gaussian_pv(ts_hour, std):
     # and a gaussian curve defined by standard deviation
     x = np.linspace(0, 24 * ts_hour, 24 * ts_hour)
     mean = 12 * ts_hour
+    std = std * ts_hour
     return np.exp(-((x - mean) ** 2) / (2 * std ** 2))
 
 

--- a/tests/test_actor.py
+++ b/tests/test_actor.py
@@ -5,7 +5,7 @@ from simply.actor import Actor, create_random
 
 
 class TestActor:
-    df = pd.DataFrame(np.random.rand(24, 3), columns=["load", "pv", "prices"])
+    df = pd.DataFrame(np.random.rand(24, 4), columns=["load", "pv", "prices", "schedule"])
 
     def test_init(self):
         # actor_id, dataframe, load_scale, power_scale, pm (?)

--- a/tests/test_market.py
+++ b/tests/test_market.py
@@ -66,28 +66,28 @@ class TestMarket:
         m = Market(0)
         # round to energy unit
         m.energy_unit = 0.1
-        m.accept_order(Order(1, 0, 0, None, 0.1, 0))
+        m.accept_order(Order(1, 0, 0, None, 0.1, 1))
         assert m.orders.at[0, "energy"] == pytest.approx(0.1)
-        m.accept_order(Order(1, 0, 0, None, 0.3, 0))
+        m.accept_order(Order(1, 0, 0, None, 0.3, 1))
         assert m.orders.at[1, "energy"] == pytest.approx(0.3)
         # below energy unit
-        m.accept_order(Order(1, 0, 0, None, 0.09, 0))
+        m.accept_order(Order(1, 0, 0, None, 0.09, 1))
         assert len(m.orders) == 2
         # round down
-        m.accept_order(Order(1, 0, 0, None, 0.55, 0))
+        m.accept_order(Order(1, 0, 0, None, 0.55, 1))
         assert m.orders.at[2, "energy"] == pytest.approx(0.5)
         # reset orders
         m.orders = m.orders[:0]
         m.energy_unit = 1
-        m.accept_order(Order(1, 0, 0, None, 1, 0))
+        m.accept_order(Order(1, 0, 0, None, 1, 1))
         assert m.orders.at[0, "energy"] == pytest.approx(1)
-        m.accept_order(Order(1, 0, 0, None, 3, 0))
+        m.accept_order(Order(1, 0, 0, None, 3, 1))
         assert m.orders.at[1, "energy"] == pytest.approx(3)
         # below energy unit
-        m.accept_order(Order(1, 0, 0, None, 0.9, 0))
+        m.accept_order(Order(1, 0, 0, None, 0.9, 1))
         assert len(m.orders) == 2
         # round down
-        m.accept_order(Order(1, 0, 0, None, 5.5, 0))
+        m.accept_order(Order(1, 0, 0, None, 5.5, 1))
         assert m.orders.at[2, "energy"] == pytest.approx(5)
 
     def test_get_bids(self):


### PR DESCRIPTION
- add generation script
- add actor generation from csv
- add scenario generation sampling from csv folder
- rearrange schedule and price initial read in and updates and order generation accordingly
- add error checks
- correct pv profile for time steps other than 1h
- read in prediction error time series seperately (currently allways zero)