### PR TITLE
Update docs to reflect the fact that PAC can incorporate grid fees

### DIFF
--- a/doc/source/matching_strategies.rst
+++ b/doc/source/matching_strategies.rst
@@ -111,9 +111,9 @@ The table below illustrates the matching of the :ref:`example_scenario`:
 +--------------------------------+-------------------------------+----------------+
 | Bids                           | Asks                          | Matched Price  |
 +================================+===============================+================+
-| actor 1, order_id 0, price 10  | actor 3, order_id 4, price 4  | 6              |
+| actor 1, order_id 0, price 10  | actor 3, order_id 4, price 4  | 7              |
 +--------------------------------+-------------------------------+----------------+
-| actor 0, order_id 2, price 10  | actor 3, order_id 3, price 6  | 6              |
+| actor 0, order_id 2, price 10  | actor 3, order_id 3, price 6  | 7              |
 +--------------------------------+-------------------------------+----------------+
 | actor 1, order_id 1, price 7   |                               |                |
 +--------------------------------+-------------------------------+----------------+


### PR DESCRIPTION
This change to the docs was missed when the grid fee feature was originally added to the grid fee matrix.