### PR TITLE
Gridfeedoc

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,7 +4,7 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.10"
-  
+  warnings: false
 
 python:
   install:
@@ -13,5 +13,5 @@ python:
 sphinx:
   builder: html
   configuration: doc/source/conf.py
-  fail_on_warning: false
+  
   

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,7 +4,7 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.10"
-  warnings: false
+  
 
 python:
   install:
@@ -13,5 +13,5 @@ python:
 sphinx:
   builder: html
   configuration: doc/source/conf.py
-  fail_on_warning: true
+  fail_on_warning: false
   

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,6 +4,7 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.10"
+  warnings: false
 
 python:
   install:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,7 +4,8 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.10"
-  warnings: false
+  warnings:
+    - "all"
 
 python:
   install:
@@ -13,3 +14,4 @@ python:
 sphinx:
   builder: html
   configuration: doc/source/conf.py
+

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,5 +13,3 @@ python:
 sphinx:
   builder: html
   configuration: doc/source/conf.py
-  
-  

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -12,9 +12,15 @@ BUILDDIR      = build
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile
+.PHONY: help Makefile clean html
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+clean:
+	@rm -rf $(BUILDDIR)/*
+
+html:
+	@$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -57,3 +57,10 @@ html_theme = 'sphinx_rtd_theme'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+
+warnings = {
+    'ignore': [
+        "No Configuration file path was provided.",
+        "No project_dir was provided."
+    ],
+}

--- a/doc/source/matching_strategies.rst
+++ b/doc/source/matching_strategies.rst
@@ -40,6 +40,105 @@ Grid-fees are calculated for each order using the following grid fee matrix:
 | Origin Cluster: 1  | 1                        | 0                       |
 +--------------------+--------------------------+-------------------------+
 
+.. _grid_fee_matrix:
+
+Methods to Enter Grid Fee Matrix
+--------------------------------
+
+There are two primary methods to input a grid fee matrix into the Simply Simulation:
+
+1. Providing a Complete Grid Fee Matrix
+2. Building a Grid Fee Matrix from Configuration Files
+
+Providing an Already Complete Grid Fee Matrix
+---------------------------------------------
+
+Format
+~~~~~~
+
+- The grid fee matrix should be provided in a structured format such as JSON or CSV.
+
+Placement
+~~~~~~~~~
+
+- Place the complete grid fee matrix in the designated input location within the simulation environment, as specified in the simulation documentation or configuration settings.
+
+Requirements
+~~~~~~~~~~~~
+
+Names/Identifiers
+"""""""""""""""""
+
+- Each row and column must be labeled with unique identifiers representing different clusters or nodes.
+- Example Identifiers:
+  - **Network Lines:** line_1, line_2, line_n
+  - **Nodes or Clusters:** node_A, node_B, node_C
+
+Units
+"""""
+
+- Specify consistent units for both row and column headers to avoid confusion (e.g., USD, EUR).
+
+Weight Factor
+"""""""""""""
+
+- The weight factor describes the relationship between grid fee and cumulative power network edge weights.
+
+Example JSON Grid Fee Matrix
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+:: 
+
+   {
+     "grid_fees": [
+       {
+         "name": "transmission_fee",
+         "unit": "$/kWh",
+         "value": 0.05
+       },
+       {
+         "name": "distribution_fee",
+         "unit": "$/kWh",
+         "value": 0.03
+       }
+     ]
+   }
+
+Building a Grid Fee Matrix from Config Files
+--------------------------------------------
+
+Composition from Config Files
+""""""""""""""""""""""""""""""
+
+The grid fee matrix can be composed by reading entries from configuration files using the following attributes:
+
+- ``default_grid_fee``: Default grid fee used by the market maker.
+- ``local_grid_fee``: Local grid fee to be used.
+- ``weight_factor``: Factor describing the relationship of grid fee to cumulative power network edge weights.
+
+Steps to Build Grid Fee Matrix
+""""""""""""""""""""""""""""""
+
+1. Retrieve ``default_grid_fee``, ``local_grid_fee``, and ``weight_factor`` values from the configuration file.
+2. Use these values to calculate or define the grid fee matrix entries.
+
+Example Configuration Entries
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+:: 
+
+   #--------------------------
+   # market
+   #--------------------------
+   # default grid_fee to be used by market maker
+   default_grid_fee = 0.09
+   # local grid fee to be used
+   local_grid_fee = 0
+   # factor describing the relation of grid fee to cumulative power network edge weights
+   weight_factor = 0.03
+
+Entering a grid fee matrix into a simulation is essential for accurate cost calculations related to using the grid. Whether you choose to provide a complete grid fee matrix or build one from configuration file entries, ensure proper format, identifiers, units, and values. By following these guidelines, you can successfully integrate the grid fee matrix into your simulation for precise cost estimations.
+
 Bids and Asks
 ---------------
 

--- a/doc/source/matching_strategies.rst
+++ b/doc/source/matching_strategies.rst
@@ -137,7 +137,7 @@ Example Configuration Entries
    # factor describing the relation of grid fee to cumulative power network edge weights
    weight_factor = 0.03
 
-Entering a grid fee matrix into a simulation is essential for accurate cost calculations related to using the grid. Whether you choose to provide a complete grid fee matrix or build one from configuration file entries, ensure proper format, identifiers, units, and values. By following these guidelines, you can successfully integrate the grid fee matrix into your simulation for precise cost estimations.
+Entering a grid fee matrix into a simulation is essential for accurate cost calculations related to using the grid. Ensure proper format, identifiers, units, and values for the rate matrix, whether complete or created from config file entries.
 
 Bids and Asks
 ---------------

--- a/doc/source/matching_strategies.rst
+++ b/doc/source/matching_strategies.rst
@@ -82,7 +82,7 @@ Units
 Weight Factor
 """""""""""""
 
-- The weight factor describes the relationship between grid fee and cumulative power network edge weights.
+- The weight factor describes the relationship between grid fee and cumulative power network edge weight between two nodes in the network. The cumulative weight is the sum of all edge weights along the shortest path in the network between those nodes. If there are multiple nodes per cluster, nodes of one cluster have equivalent cumulative weights to all nodes of of another cluster.
 
 Example JSON Grid Fee Matrix
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/matching_strategies.rst
+++ b/doc/source/matching_strategies.rst
@@ -56,27 +56,25 @@ Providing an Already Complete Grid Fee Matrix
 ---------------------------------------------
 
 Format: The grid fee matrix should be provided in a structured format such as JSON or CSV.
-~~~~~~~
 
 Placement: Place the complete grid fee matrix in the designated input location within the simulation environment, as specified in the simulation documentation or 
-~~~~~~~~~~
 configuration settings.
 
 Requirements
 ~~~~~~~~~~~~
-   Names/Identifiers
-   """""""""""""""""
-      - Each row and column must be labeled with unique identifiers representing different clusters or nodes.
-      - Example Identifiers:
-        - **Network Lines:** line_1, line_2, line_n
-        - **Nodes or Clusters:** node_A, node_B, node_C
-   Units
-   """""
-      - Specify consistent units for both row and column headers to avoid confusion (e.g., USD, EUR).
+Names/Identifiers
+"""""""""""""""""
+   - Each row and column must be labeled with unique identifiers representing different clusters or nodes.
+   - Example Identifiers:
+      - **Network Lines:** line_1, line_2, line_n
+      - **Nodes or Clusters:** node_A, node_B, node_C
+Units
+"""""
+   - Specify consistent units for both row and column headers to avoid confusion (e.g., USD, EUR).
 
-   Weight Factor
-   """""""""""""
-      - The weight factor describes the relationship between grid fee and cumulative power network edge weight between two nodes in the network. The cumulative weight is the sum of all edge weights along the shortest path in the network between those nodes. If there are multiple nodes per cluster, nodes of one cluster have equivalent cumulative weights to all nodes of another cluster.
+Weight Factor
+"""""""""""""
+   - The weight factor describes the relationship between grid fee and cumulative power network edge weight between two nodes in the network. The cumulative weight is the sum of all edge weights along the shortest path in the network between those nodes. If there are multiple nodes per cluster, nodes of one cluster have equivalent cumulative weights to all nodes of another cluster.
 
 Example JSON Grid Fee Matrix
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/matching_strategies.rst
+++ b/doc/source/matching_strategies.rst
@@ -45,7 +45,7 @@ Grid-fees are calculated for each order using the following grid fee matrix:
 Methods to Enter Grid Fee Matrix
 --------------------------------
 
-There are two primary methods to input a grid fee matrix into the Simply Simulation:
+There are two methods to define a grid fee matrix for the simply simulation:
 
 1. Providing a Complete Grid Fee Matrix
 2. Building a Grid Fee Matrix from Configuration Files

--- a/doc/source/matching_strategies.rst
+++ b/doc/source/matching_strategies.rst
@@ -112,9 +112,9 @@ Composition from Config Files
 
 The grid fee matrix can be composed by reading entries from configuration files using the following attributes:
 
-- ``default_grid_fee``: Default grid fee used by the market maker.
-- ``local_grid_fee``: Local grid fee to be used.
-- ``weight_factor``: Factor describing the relationship of grid fee to cumulative power network edge weights.
+- ``default_grid_fee``: Default grid fee applied for trades with the market maker
+- ``local_grid_fee``: Local grid fee applied for trades within a cluster
+- ``weight_factor``: Factor describing the relationship of grid fee to cumulative power network edge weights (see description above)
 
 Steps to Build Grid Fee Matrix
 """"""""""""""""""""""""""""""

--- a/doc/source/matching_strategies.rst
+++ b/doc/source/matching_strategies.rst
@@ -55,28 +55,28 @@ There are two methods to define a grid fee matrix for the simply simulation:
 Providing an Already Complete Grid Fee Matrix
 ---------------------------------------------
 
-Format: - The grid fee matrix should be provided in a structured format such as JSON or CSV.
+Format: The grid fee matrix should be provided in a structured format such as JSON or CSV.
 ~~~~~~~
 
-Placement: - Place the complete grid fee matrix in the designated input location within the simulation environment, as specified in the simulation documentation or 
+Placement: Place the complete grid fee matrix in the designated input location within the simulation environment, as specified in the simulation documentation or 
 ~~~~~~~~~~
 configuration settings.
 
 Requirements
 ~~~~~~~~~~~~
-Names/Identifiers
-"""""""""""""""""
-- Each row and column must be labeled with unique identifiers representing different clusters or nodes.
-- Example Identifiers:
-  - **Network Lines:** line_1, line_2, line_n
-  - **Nodes or Clusters:** node_A, node_B, node_C
-Units
-"""""
-- Specify consistent units for both row and column headers to avoid confusion (e.g., USD, EUR).
+   Names/Identifiers
+   """""""""""""""""
+      - Each row and column must be labeled with unique identifiers representing different clusters or nodes.
+      - Example Identifiers:
+        - **Network Lines:** line_1, line_2, line_n
+        - **Nodes or Clusters:** node_A, node_B, node_C
+   Units
+   """""
+      - Specify consistent units for both row and column headers to avoid confusion (e.g., USD, EUR).
 
-Weight Factor
-"""""""""""""
-- The weight factor describes the relationship between grid fee and cumulative power network edge weight between two nodes in the network. The cumulative weight is the sum of all edge weights along the shortest path in the network between those nodes. If there are multiple nodes per cluster, nodes of one cluster have equivalent cumulative weights to all nodes of another cluster.
+   Weight Factor
+   """""""""""""
+      - The weight factor describes the relationship between grid fee and cumulative power network edge weight between two nodes in the network. The cumulative weight is the sum of all edge weights along the shortest path in the network between those nodes. If there are multiple nodes per cluster, nodes of one cluster have equivalent cumulative weights to all nodes of another cluster.
 
 Example JSON Grid Fee Matrix
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/matching_strategies.rst
+++ b/doc/source/matching_strategies.rst
@@ -57,19 +57,16 @@ There are two methods to define a grid fee matrix for the simply simulation:
 Providing an Already Complete Grid Fee Matrix
 ---------------------------------------------
 
-Format
-^^^^^^
+**Format:**
 The grid fee matrix should be provided in a structured format such as JSON or CSV.
 
-Placement
-^^^^^^^^^
+**Placement:**
 Place the complete grid fee matrix in the designated input location within the simulation environment, as specified in the simulation documentation or configuration settings.
 
 Requirements
 ------------
 
-Names/Identifiers
-~~~~~~~~~~~~~~~~~
+**Names/Identifiers:**
 Each row and column must be labeled with unique identifiers representing different clusters or nodes.
 
 **Example Identifiers:**
@@ -77,16 +74,13 @@ Each row and column must be labeled with unique identifiers representing differe
 - **Network Lines:** line_1, line_2, line_n
 - **Nodes or Clusters:** node_A, node_B, node_C
 
-Units
-~~~~~
+**Units:**
 Specify consistent units for both row and column headers to avoid confusion (e.g., USD, EUR).
 
-Weight Factor
-~~~~~~~~~~~~~
+**Weight Factor:**
 The weight factor describes the relationship between grid fee and cumulative power network edge weight between two nodes in the network. The cumulative weight is the sum of all edge weights along the shortest path in the network between those nodes. If there are multiple nodes per cluster, nodes of one cluster have equivalent cumulative weights to all nodes of another cluster.
 
-Example JSON Grid Fee Matrix
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+**Example JSON Grid Fee Matrix**
 
 .. code-block:: json
 
@@ -110,16 +104,15 @@ Example JSON Grid Fee Matrix
 Building a Grid Fee Matrix from Config Files
 --------------------------------------------
 
-Composition from Config Files
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+**Composition from Config Files**
+
 The grid fee matrix can be composed by reading entries from configuration files using the following attributes:
 
 - ``default_grid_fee``: Default grid fee applied for trades with the market maker
 - ``local_grid_fee``: Local grid fee applied for trades within a cluster
 - ``weight_factor``: Factor describing the relationship of grid fee to cumulative power network edge weights (see description above)
 
-Example Configuration Entries
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+**Example Configuration Entries**
 
 .. code-block:: python
 

--- a/doc/source/matching_strategies.rst
+++ b/doc/source/matching_strategies.rst
@@ -45,48 +45,41 @@ Grid-fees are calculated for each order using the following grid fee matrix:
 Methods to Enter Grid Fee Matrix
 --------------------------------
 
+Entering a grid fee matrix into a simulation is essential for accurate cost calculations related to using the grid. Ensure proper format, identifiers, units, and values for the rate matrix, whether complete or created from config file entries.
+
 There are two methods to define a grid fee matrix for the simply simulation:
 
-1. Providing a Complete Grid Fee Matrix
-2. Building a Grid Fee Matrix from Configuration Files
+1. [Providing a Complete Grid Fee Matrix](#Providing-a-Complete-Grid-Fee-Matrix)
+2. [Building a Grid Fee Matrix from Configuration Files](#Building-a-Grid-Fee-Matrix-from-Configuration-Files)
 
 Providing an Already Complete Grid Fee Matrix
 ---------------------------------------------
 
-Format
-~~~~~~
+Format: - The grid fee matrix should be provided in a structured format such as JSON or CSV.
+~~~~~~~
 
-- The grid fee matrix should be provided in a structured format such as JSON or CSV.
-
-Placement
-~~~~~~~~~
-
-- Place the complete grid fee matrix in the designated input location within the simulation environment, as specified in the simulation documentation or configuration settings.
+Placement: - Place the complete grid fee matrix in the designated input location within the simulation environment, as specified in the simulation documentation or 
+~~~~~~~~~~
+configuration settings.
 
 Requirements
 ~~~~~~~~~~~~
-
 Names/Identifiers
 """""""""""""""""
-
 - Each row and column must be labeled with unique identifiers representing different clusters or nodes.
 - Example Identifiers:
   - **Network Lines:** line_1, line_2, line_n
   - **Nodes or Clusters:** node_A, node_B, node_C
-
 Units
 """""
-
 - Specify consistent units for both row and column headers to avoid confusion (e.g., USD, EUR).
 
 Weight Factor
 """""""""""""
-
-- The weight factor describes the relationship between grid fee and cumulative power network edge weight between two nodes in the network. The cumulative weight is the sum of all edge weights along the shortest path in the network between those nodes. If there are multiple nodes per cluster, nodes of one cluster have equivalent cumulative weights to all nodes of of another cluster.
+- The weight factor describes the relationship between grid fee and cumulative power network edge weight between two nodes in the network. The cumulative weight is the sum of all edge weights along the shortest path in the network between those nodes. If there are multiple nodes per cluster, nodes of one cluster have equivalent cumulative weights to all nodes of another cluster.
 
 Example JSON Grid Fee Matrix
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 :: 
 
    {
@@ -116,12 +109,6 @@ The grid fee matrix can be composed by reading entries from configuration files 
 - ``local_grid_fee``: Local grid fee applied for trades within a cluster
 - ``weight_factor``: Factor describing the relationship of grid fee to cumulative power network edge weights (see description above)
 
-Steps to Build Grid Fee Matrix
-""""""""""""""""""""""""""""""
-
-1. Retrieve ``default_grid_fee``, ``local_grid_fee``, and ``weight_factor`` values from the configuration file.
-2. Use these values to calculate or define the grid fee matrix entries.
-
 Example Configuration Entries
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -137,7 +124,6 @@ Example Configuration Entries
    # factor describing the relation of grid fee to cumulative power network edge weights
    weight_factor = 0.03
 
-Entering a grid fee matrix into a simulation is essential for accurate cost calculations related to using the grid. Ensure proper format, identifiers, units, and values for the rate matrix, whether complete or created from config file entries.
 
 Bids and Asks
 ---------------

--- a/doc/source/matching_strategies.rst
+++ b/doc/source/matching_strategies.rst
@@ -49,10 +49,9 @@ Entering a grid fee matrix into a simulation is essential for accurate cost calc
 
 There are two methods to define a grid fee matrix for the simply simulation:
 
-1. :ref:`Providing a Complete Grid Fee Matrix`
-2. :ref:`Building a Grid Fee Matrix from Configuration Files`
+1. Providing a Complete Grid Fee Matrix
+2. Building a Grid Fee Matrix from Configuration Files
 
-.. _Providing a Complete Grid Fee Matrix:
 
 Providing an Already Complete Grid Fee Matrix
 ---------------------------------------------
@@ -99,7 +98,6 @@ The weight factor describes the relationship between grid fee and cumulative pow
      ]
    }
 
-.. _Building a Grid Fee Matrix from Configuration Files:
 
 Building a Grid Fee Matrix from Config Files
 --------------------------------------------

--- a/doc/source/matching_strategies.rst
+++ b/doc/source/matching_strategies.rst
@@ -49,36 +49,46 @@ Entering a grid fee matrix into a simulation is essential for accurate cost calc
 
 There are two methods to define a grid fee matrix for the simply simulation:
 
-1. [Providing a Complete Grid Fee Matrix](#Providing-a-Complete-Grid-Fee-Matrix)
-2. [Building a Grid Fee Matrix from Configuration Files](#Building-a-Grid-Fee-Matrix-from-Configuration-Files)
+1. :ref:`Providing a Complete Grid Fee Matrix`
+2. :ref:`Building a Grid Fee Matrix from Configuration Files`
+
+.. _Providing a Complete Grid Fee Matrix:
 
 Providing an Already Complete Grid Fee Matrix
 ---------------------------------------------
 
-Format: The grid fee matrix should be provided in a structured format such as JSON or CSV.
+Format
+^^^^^^
+The grid fee matrix should be provided in a structured format such as JSON or CSV.
 
-Placement: Place the complete grid fee matrix in the designated input location within the simulation environment, as specified in the simulation documentation or 
-configuration settings.
+Placement
+^^^^^^^^^
+Place the complete grid fee matrix in the designated input location within the simulation environment, as specified in the simulation documentation or configuration settings.
 
 Requirements
-~~~~~~~~~~~~
+------------
+
 Names/Identifiers
-"""""""""""""""""
-   - Each row and column must be labeled with unique identifiers representing different clusters or nodes.
-   - Example Identifiers:
-      - **Network Lines:** line_1, line_2, line_n
-      - **Nodes or Clusters:** node_A, node_B, node_C
+~~~~~~~~~~~~~~~~~
+Each row and column must be labeled with unique identifiers representing different clusters or nodes.
+
+**Example Identifiers:**
+
+- **Network Lines:** line_1, line_2, line_n
+- **Nodes or Clusters:** node_A, node_B, node_C
+
 Units
-"""""
-   - Specify consistent units for both row and column headers to avoid confusion (e.g., USD, EUR).
+~~~~~
+Specify consistent units for both row and column headers to avoid confusion (e.g., USD, EUR).
 
 Weight Factor
-"""""""""""""
-   - The weight factor describes the relationship between grid fee and cumulative power network edge weight between two nodes in the network. The cumulative weight is the sum of all edge weights along the shortest path in the network between those nodes. If there are multiple nodes per cluster, nodes of one cluster have equivalent cumulative weights to all nodes of another cluster.
+~~~~~~~~~~~~~
+The weight factor describes the relationship between grid fee and cumulative power network edge weight between two nodes in the network. The cumulative weight is the sum of all edge weights along the shortest path in the network between those nodes. If there are multiple nodes per cluster, nodes of one cluster have equivalent cumulative weights to all nodes of another cluster.
 
 Example JSON Grid Fee Matrix
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-:: 
+
+.. code-block:: json
 
    {
      "grid_fees": [
@@ -95,12 +105,13 @@ Example JSON Grid Fee Matrix
      ]
    }
 
+.. _Building a Grid Fee Matrix from Configuration Files:
+
 Building a Grid Fee Matrix from Config Files
 --------------------------------------------
 
 Composition from Config Files
-""""""""""""""""""""""""""""""
-
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 The grid fee matrix can be composed by reading entries from configuration files using the following attributes:
 
 - ``default_grid_fee``: Default grid fee applied for trades with the market maker
@@ -110,7 +121,7 @@ The grid fee matrix can be composed by reading entries from configuration files 
 Example Configuration Entries
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:: 
+.. code-block:: python
 
    #--------------------------
    # market
@@ -121,7 +132,6 @@ Example Configuration Entries
    local_grid_fee = 0
    # factor describing the relation of grid fee to cumulative power network edge weights
    weight_factor = 0.03
-
 
 Bids and Asks
 ---------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pytest
 pathlib
 numpy
 pydot
+sphinx_rtd_theme>=0.5.2

--- a/simply/config.py
+++ b/simply/config.py
@@ -43,9 +43,11 @@ class Config:
     :param cfg_file: configuration file path with the attributes listed above.
     :type cfg_file: str
     :keyword cfg_file: start
+    :param project_dir: directory path for the project. If not provided, default project_dir ./projects/example_projects/example_project is used.
+    :type project_dir: str
     """
 
-    def __init__(self, cfg_file, project_dir):
+    def __init__(self, cfg_file, project_dir="./projects/example_projects/example_project"):
         global config
         config = self
         global parser
@@ -61,7 +63,7 @@ class Config:
             warnings.warn("No project_dir was provided. Default project_dir ./projects/"
                           "example_projects/example_project is used")
             project_dir = "projects/example_projects/example_project"
-        elif not Path(project_dir):
+        elif not Path(project_dir).is_dir():
             warnings.warn(f"{project_dir} was provided as directory, but this directory does not "
                           f"exist. Default project_dir ./projects/example_project will be used.")
             project_dir = "projects/example_projects/example_project"

--- a/simply/market_fair.py
+++ b/simply/market_fair.py
@@ -13,8 +13,10 @@ def time_it(function, timers={}):
 
     :param function: function do be decorated
     :type function: function
+    
     :param timers: storage for cumulated time and call number
     :type timers: dict
+    
     :return: decorated function or timer if given function is None
     :rtype function or dict
 

--- a/simply/market_fair.py
+++ b/simply/market_fair.py
@@ -43,6 +43,7 @@ def time_it(function, timers={}):
     return sorted_timer
 
 
+
 class BestCluster:
     """Class which keeps track of attributes resolving around a cluster and
     implements functionality to keep the best algorithm more readable.


### PR DESCRIPTION
This pull request includes the document I added to the Grid Fee Matrix section of the Simply Simulation documentation. 

1. Added an example table to clearly illustrate the structure of the grid fee matrix.
2. Provided detailed explanations under two main headings for entering the grid fee matrix.
3. Added an example grid fee matrix definition in JSON format.
4. Clearly outlined the method to construct a grid fee matrix from configuration files.
5. Added sample entries for the configuration file.
6. Included a conclusion section at the end of the document.